### PR TITLE
Update ffmpeg arguments so that jsmpeg works correctly.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,4 +54,4 @@ ws.on('message', (data, flags) => {
 })
 ```
 
-You can find a live stream JSMPEG example here : https://github.com/phoboslab/jsmpeg/blob/master/stream-example.html
+You can find a live stream JSMPEG example here : https://github.com/phoboslab/jsmpeg/blob/master/view-stream.html

--- a/src/mpeg1muxer.js
+++ b/src/mpeg1muxer.js
@@ -8,7 +8,7 @@ class Mpeg1Muxer extends EventEmitter {
     
     this.url = options.url
     
-    this.stream = child_process.spawn("ffmpeg", ["-rtsp_transport", "tcp", "-i", this.url, '-f', 'mpegts', '-codec:v', 'mpeg1video', '-b:v', '180k', '-r', '30', '-'], {
+    this.stream = child_process.spawn("ffmpeg", ["-rtsp_transport", "tcp", "-i", this.url, '-f', 'mpegts', '-codec:v', 'mpeg1video', '-bf', '0', '-codec:a', 'mp2', '-r', '30', '-'], {
       detached: false
     })
     


### PR DESCRIPTION
Based on the comment https://github.com/phoboslab/jsmpeg/issues/149#issuecomment-289283701 it seems like the ffmpeg arguments are outdated. I've updated them to match what was mentioned there as well as updated the example link as the old linked to a file that doesn't exist.

I've also setup a [docker based example of all this](https://github.com/KyleLilly/rtsp-streamer) that I'd be happy to add to the readme if you think it'd be useful.