### PR TITLE
Updates readme file, there is a major typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ npm i node-rtsp-stream-es6
 ## Server
 
 ```javascript
-const Stream = require('videoStream')
+const Stream = require('node-rtsp-stream-es6')
 
 const options = {
   name: 'streamName',


### PR DESCRIPTION
requiring the package fails because its mentioned as videoStream, while it should be node-rtsp-stream-es6